### PR TITLE
feat: add restructuredtext support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,12 +54,14 @@ dependencies = [
  "ignore",
  "serde",
  "termcolor",
+ "textwrap",
  "thiserror",
  "tokio",
  "toml",
  "tree-sitter",
  "tree-sitter-md",
  "tree-sitter-org",
+ "tree-sitter-rst",
 ]
 
 [[package]]
@@ -394,6 +396,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +432,11 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -518,10 +531,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-rst"
+version = "0.0.1"
+source = "git+https://github.com/zegervdv/tree-sitter-rst?branch=rust-lib-upstep#462ef5c2d21025de0347d9fc08aeefb11e8f0903"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,14 @@ futures = "0.3.21"
 ignore = "0.4.18"
 serde = { version = "1.0.138", features = ["derive"] }
 termcolor = "1.1.3"
+textwrap = "0.15.0"
 thiserror = "1.0.31"
 tokio = { version = "1.20.0", features = ["macros", "fs", "rt-multi-thread"] }
 toml = "0.5.9"
 tree-sitter = "~0.20"
 tree-sitter-md = "0.1.1"
 tree-sitter-org = "1.3.0"
+tree-sitter-rst = "0.1.0"
 
 [build-dependencies]
 cc = "1.0.73"

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -14,6 +14,11 @@ pub fn get_tree(parser_lang: &str, text: &[u8]) -> Option<tree_sitter::Tree> {
                 .set_language(tree_sitter_org::language())
                 .expect("Could not load org grammar");
         }
+        "restructuredtext" => {
+            parser
+                .set_language(tree_sitter_rst::language())
+                .expect("Could not load restructuredtext grammar");
+        }
         _ => {
             return None;
         }
@@ -48,6 +53,20 @@ pub fn get_query(parser_lang: &str) -> Option<tree_sitter::Query> {
             )
             .expect("Could not load org query"),
         ),
+        "restructuredtext" => Some(
+            tree_sitter::Query::new(
+                tree_sitter_rst::language(),
+                r#"
+                    (directive
+                        name: (type) @_name
+                        (#match? @_name "code")
+                        body: (body
+                            (arguments) @language
+                            (content) @content)) @codeblock
+                "#,
+            )
+            .expect("Could not load restructuredtext query"),
+        ),
         _ => None,
     }
 }
@@ -59,6 +78,9 @@ pub fn get_parser_lang_from_filename(filename: &str) -> Option<&str> {
     }
     if filename.ends_with(".org") {
         return Some("org");
+    }
+    if filename.ends_with(".rst") {
+        return Some("restructuredtext");
     }
     None
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -62,7 +62,9 @@ pub fn get_query(parser_lang: &str) -> Option<tree_sitter::Query> {
                         (#match? @_name "code")
                         body: (body
                             (arguments) @language
-                            (content) @content)) @codeblock
+                            (content) @content
+                            (#offset! @content 0 0 1 0))) @codeblock
+                    
                 "#,
             )
             .expect("Could not load restructuredtext query"),
@@ -81,6 +83,42 @@ pub fn get_parser_lang_from_filename(filename: &str) -> Option<&str> {
     }
     if filename.ends_with(".rst") {
         return Some("restructuredtext");
+    }
+    None
+}
+
+pub fn handle_directive(
+    directive: &str,
+    range: &tree_sitter::Range,
+    args: &Vec<tree_sitter::QueryPredicateArg>,
+) -> Option<tree_sitter::Range> {
+    match directive {
+        "offset!" => {
+            let start_row_offset = match &args[1] {
+                tree_sitter::QueryPredicateArg::String(value) => value.parse::<usize>().unwrap(),
+                _ => panic!("Unexpected argument type for offset!"),
+            };
+            let start_col_offset = match &args[2] {
+                tree_sitter::QueryPredicateArg::String(value) => value.parse::<usize>().unwrap(),
+                _ => panic!("Unexpected argument type for offset!"),
+            };
+            let end_row_offset = match &args[3] {
+                tree_sitter::QueryPredicateArg::String(value) => value.parse::<usize>().unwrap(),
+                _ => panic!("Unexpected argument type for offset!"),
+            };
+            let end_col_offset = match &args[4] {
+                tree_sitter::QueryPredicateArg::String(value) => value.parse::<usize>().unwrap(),
+                _ => panic!("Unexpected argument type for offset!"),
+            };
+
+            let mut new_range = range.clone();
+            new_range.start_point.row = range.start_point.row + start_row_offset;
+            new_range.start_point.column = range.start_point.column + start_col_offset;
+            new_range.end_point.row = range.end_point.row + end_row_offset;
+            new_range.end_point.column = range.end_point.column + end_col_offset;
+            return Some(new_range);
+        }
+        &_ => {}
     }
     None
 }


### PR DESCRIPTION
I want to add support for reStructuredText (rst) files.

I have the basic query working, it recognizes the language and extracts the code.
But there is some trouble with the indents.
I'll need to strip the indent before going to the formatter (black seems to fail on this) and re-apply them on the result.

Currently a test rst file:
``` rst
########
test
########
.. code:: lua

  local bar = require 'bar'
    bar.setup {
      foo = {},
      baz = { 'aa', 'bb' },
    }
```
results in:
``` rst
########
test
########
.. code:: lua

local bar = require 'bar'
bar.setup {
  foo = {},
  baz = { 'aa', 'bb' },
}
    }
```

So, still some work to be done, but I already wanted to get some feedback or input before continuing.
This is also my first foray into rust. 

I had to fork [tree-sitter-rst](https://github.com/stsewd/tree-sitter-rst) to upstep `tree-sitter` to 0.20 and add the `scanner.c` code to the lib. I'll try to get that merged, but I can continue from the forked repo for now.