### PR TITLE
fix: change command parser to not trim whitespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "cbfmt"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "atty",
  "cc",


### PR DESCRIPTION
This is to allow for commands where passing an empty string as argument
has significance. This should however only be relevant in exceptional
cases. For example, shellharden handles reading from stdin by receiving
an empty string as its "file" argument (in shell done via ''/""):

```sh
$ shellharden --transform '' < file
```

A translation to Rust std::process style of spawning processes would be:
cmd:   "shellharden"
args: ["--transform", ""]

By using `.split_whitespace()` to separate the components of a command,
any trailing as well as contiguous sequences of whitespaces are removed,
making it impossible to express the same command via the TOML config:

```toml
[languages]
sh = ["shellharden --transform "]
```

This PR changes the command parser to treat whitespace individually, and
not trim any away. I guess one drawback of this is that the commands
expressed in the TOML config drift further away from what one perhaps
would expect. By this I mean a shell-like syntax where whitespace don't
matter as much (until they do, by which time you're in for a world of
pain).

I wouldn't mind if this was declined due to similar reasoning, figured
I'd open it anyway and at least highlight the problem. In that case I'll
try to get `-` supported as a filename representing stdin in
`shellharden`, this PR would be a good motivation for it :)
